### PR TITLE
fix: proper timezone on workshop detail page

### DIFF
--- a/src/pages/workshops/[workshop].astro
+++ b/src/pages/workshops/[workshop].astro
@@ -10,6 +10,7 @@ import TalkDetail from "../../components/TalkDetail.astro";
 const formatTime = (date: string) => {
 	return new Date(date).toLocaleTimeString("en-US", {
 		timeStyle: "short",
+		timeZone: "Europe/Zurich",
 	});
 };
 


### PR DESCRIPTION
This PR fixes the previously incorrect time display when using a server outside of our timezone.

Demo: https://frontconference-website-git-feat-795d18-front-conference-zurich.vercel.app/workshops/the-secrets-of-web-performance