### PR TITLE
feat: add lite video embeds for vimeo and youtube

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/vercel": "^7.4.0",
+        "@justinribeiro/lite-youtube": "^1.5.0",
+        "@slightlyoff/lite-vimeo": "^0.1.2",
         "airtable": "^0.12.2",
         "astro": "^4.5.9",
         "astro-icon": "^1.1.0",
@@ -1081,6 +1083,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@justinribeiro/lite-youtube": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@justinribeiro/lite-youtube/-/lite-youtube-1.5.0.tgz",
+      "integrity": "sha512-TU92RKtz9BI9PRYrVwDIUsnFadLZtqRKWl1ZOdbxb7roJDb8Dd/xURllAsLEmCg6oJNyhXlVa5RsnUc0EKd8Cw=="
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -1304,6 +1311,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.2.0.tgz",
       "integrity": "sha512-OlFvx+nyr5C8zpcMBnSGir0YPD6K11uYhouqhNmm1qLiis4GA7SsGtu07r9gKS9omks8RtQqHrJL4S+lqWK01A=="
+    },
+    "node_modules/@slightlyoff/lite-vimeo": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@slightlyoff/lite-vimeo/-/lite-vimeo-0.1.2.tgz",
+      "integrity": "sha512-KkmMgogBfAHyk+Q1MvDWmTmif5uYIKzWLoW/vbxLzafC4GldU1ssKoo7VZ+cBtH19RFHFVrxy+PMd7IRghAT6Q=="
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@astrojs/vercel": "^7.4.0",
+    "@justinribeiro/lite-youtube": "^1.5.0",
+    "@slightlyoff/lite-vimeo": "^0.1.2",
     "airtable": "^0.12.2",
     "astro": "^4.5.9",
     "astro-icon": "^1.1.0",

--- a/src/layouts/ContentLayout.astro
+++ b/src/layouts/ContentLayout.astro
@@ -18,4 +18,9 @@ const { title, metaDescription, backLinkTitle, displayBacklink, contentClass } =
 		slot="after-header"
 	/>
 	<slot />
+
+	<script>
+		import("@slightlyoff/lite-vimeo");
+		import("@justinribeiro/lite-youtube");
+	</script>
 </Layout>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -122,3 +122,8 @@ if (!currentPage || !currentPage.title) {
 		margin-block-start: var(--spacing-10x);
 	}
 </style>
+
+<script>
+	import("@slightlyoff/lite-vimeo");
+	import("@justinribeiro/lite-youtube");
+</script>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -122,8 +122,3 @@ if (!currentPage || !currentPage.title) {
 		margin-block-start: var(--spacing-10x);
 	}
 </style>
-
-<script>
-	import("@slightlyoff/lite-vimeo");
-	import("@justinribeiro/lite-youtube");
-</script>


### PR DESCRIPTION
This PR allows us to embed YouTube and Vimeo videos in a [more efficient way](https://frontendmasters.com/blog/youtube-embeds-are-bananas-heavy-and-its-fixable/) than the default embeds. 

### Testing

Before: https://frontconference.com/about
<img width="1552" alt="image" src="https://github.com/frontendconf/frontconference-website/assets/654171/f9355cf5-df6d-4ad8-870c-49c4b6a0cd23">

After: https://frontconference-website-git-feat-d4c46f-front-conference-zurich.vercel.app/about-test
<img width="1552" alt="image" src="https://github.com/frontendconf/frontconference-website/assets/654171/7910e256-96c6-4400-a3c7-b34e02de202f">